### PR TITLE
Dds message task ids

### DIFF
--- a/clients/ros1/free_fleet_client/CMakeLists.txt
+++ b/clients/ros1/free_fleet_client/CMakeLists.txt
@@ -51,10 +51,10 @@ target_include_directories(free_fleet_client
 set(testing_targets
   fake_action_server
   test_dds_sub_state
-  test_dds_pub_mode_command
-  test_dds_pub_path_command
-  test_dds_pub_sim_path_command
-  test_dds_pub_location_command
+  test_dds_pub_mode_request
+  test_dds_pub_path_request
+  test_dds_pub_sim_path_request
+  test_dds_pub_destination_request
 )
 
 foreach(target ${testing_targets})

--- a/clients/ros1/free_fleet_client/src/Client.hpp
+++ b/clients/ros1/free_fleet_client/src/Client.hpp
@@ -64,9 +64,9 @@ struct ClientConfig
 
   uint32_t dds_domain = std::numeric_limits<uint32_t>::max();
   std::string dds_state_topic = "robot_state";
-  std::string dds_mode_command_topic = "robot_mode_command";
-  std::string dds_path_command_topic = "robot_path_command";
-  std::string dds_location_command_topic = "robot_location_command";
+  std::string dds_mode_request_topic = "mode_request";
+  std::string dds_path_request_topic = "path_request";
+  std::string dds_destination_request_topic = "destination_request";
 
   float update_frequency = 10.0;
   float publish_frequency = 1.0;
@@ -145,7 +145,7 @@ private:
   void publish_robot_state();
 
   // --------------------------------------------------------------------------
-  // Receiving and handling commands in the form of location, mode and path.
+  // Receiving and handling requests in the form of location, mode and path.
 
   dds::DDSSubscribeHandler<FreeFleetData_ModeRequest>::SharedPtr 
       mode_request_sub;
@@ -166,14 +166,14 @@ private:
 
   void resume_robot();
 
-  /// In the event that within one single cycle, the client receives commands
+  /// In the event that within one single cycle, the client receives requests
   /// from all 3 sources, the priority is mode > path > location.
   ///
-  void read_commands();
+  void read_requests();
 
-  /// Handling of commands will have a similar priority, with mode > goal
+  /// Handling of requests will have a similar priority, with mode > goal
   ///
-  void handle_commands();
+  void handle_requests();
 
   // --------------------------------------------------------------------------
 

--- a/clients/ros1/free_fleet_client/src/Client.hpp
+++ b/clients/ros1/free_fleet_client/src/Client.hpp
@@ -147,14 +147,14 @@ private:
   // --------------------------------------------------------------------------
   // Receiving and handling commands in the form of location, mode and path.
 
-  dds::DDSSubscribeHandler<FreeFleetData_RobotMode>::SharedPtr 
-      mode_command_sub;
+  dds::DDSSubscribeHandler<FreeFleetData_ModeRequest>::SharedPtr 
+      mode_request_sub;
 
-  dds::DDSSubscribeHandler<FreeFleetData_Location>::SharedPtr
-      location_command_sub;
+  dds::DDSSubscribeHandler<FreeFleetData_PathRequest>::SharedPtr 
+      path_request_sub;
 
-  dds::DDSSubscribeHandler<FreeFleetData_Path>::SharedPtr 
-      path_command_sub;
+  dds::DDSSubscribeHandler<FreeFleetData_DestinationRequest>::SharedPtr
+      destination_request_sub;
 
   move_base_msgs::MoveBaseGoal location_to_goal(
       std::shared_ptr<const FreeFleetData_Location> location) const;

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.c
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.c
@@ -95,12 +95,7 @@ const dds_topic_descriptor_t FreeFleetData_RobotState_desc =
 
 static const uint32_t FreeFleetData_ModeRequest_ops [] =
 {
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.sec),
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.nanosec),
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.x),
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.y),
-  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.yaw),
-  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_ModeRequest, location.level_name),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, mode.mode),
   DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_ModeRequest, task_id),
   DDS_OP_RTS
 };
@@ -113,9 +108,9 @@ const dds_topic_descriptor_t FreeFleetData_ModeRequest_desc =
   0u,
   "FreeFleetData::ModeRequest",
   NULL,
-  8,
+  3,
   FreeFleetData_ModeRequest_ops,
-  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"ModeRequest\"><Member name=\"location\"><Type name=\"Location\"/></Member><Member name=\"task_id\"><String/></Member></Struct></Module></MetaData>"
+  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"RobotMode\"><Member name=\"mode\"><ULong/></Member></Struct><Struct name=\"ModeRequest\"><Member name=\"mode\"><Type name=\"RobotMode\"/></Member><Member name=\"task_id\"><String/></Member></Struct></Module></MetaData>"
 };
 
 

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.c
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.c
@@ -58,6 +58,7 @@ static const uint32_t FreeFleetData_RobotState_ops [] =
 {
   DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_RobotState, name),
   DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_RobotState, model),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_RobotState, task_id),
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_RobotState, mode.mode),
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_RobotState, battery_percent),
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_RobotState, location.sec),
@@ -86,15 +87,41 @@ const dds_topic_descriptor_t FreeFleetData_RobotState_desc =
   0u,
   "FreeFleetData::RobotState",
   NULL,
-  20,
+  21,
   FreeFleetData_RobotState_ops,
-  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"RobotMode\"><Member name=\"mode\"><ULong/></Member></Struct><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"RobotState\"><Member name=\"name\"><String/></Member><Member name=\"model\"><String/></Member><Member name=\"mode\"><Type name=\"RobotMode\"/></Member><Member name=\"battery_percent\"><Float/></Member><Member name=\"location\"><Type name=\"Location\"/></Member><Member name=\"path\"><Sequence><Type name=\"Location\"/></Sequence></Member></Struct></Module></MetaData>"
+  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"RobotMode\"><Member name=\"mode\"><ULong/></Member></Struct><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"RobotState\"><Member name=\"name\"><String/></Member><Member name=\"model\"><String/></Member><Member name=\"task_id\"><String/></Member><Member name=\"mode\"><Type name=\"RobotMode\"/></Member><Member name=\"battery_percent\"><Float/></Member><Member name=\"location\"><Type name=\"Location\"/></Member><Member name=\"path\"><Sequence><Type name=\"Location\"/></Sequence></Member></Struct></Module></MetaData>"
 };
 
 
-static const uint32_t FreeFleetData_Path_ops [] =
+static const uint32_t FreeFleetData_ModeRequest_ops [] =
 {
-  DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (FreeFleetData_Path, path),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.sec),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.nanosec),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.x),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.y),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_ModeRequest, location.yaw),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_ModeRequest, location.level_name),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_ModeRequest, task_id),
+  DDS_OP_RTS
+};
+
+const dds_topic_descriptor_t FreeFleetData_ModeRequest_desc =
+{
+  sizeof (FreeFleetData_ModeRequest),
+  sizeof (char *),
+  DDS_TOPIC_NO_OPTIMIZE,
+  0u,
+  "FreeFleetData::ModeRequest",
+  NULL,
+  8,
+  FreeFleetData_ModeRequest_ops,
+  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"ModeRequest\"><Member name=\"location\"><Type name=\"Location\"/></Member><Member name=\"task_id\"><String/></Member></Struct></Module></MetaData>"
+};
+
+
+static const uint32_t FreeFleetData_PathRequest_ops [] =
+{
+  DDS_OP_ADR | DDS_OP_TYPE_SEQ | DDS_OP_SUBTYPE_STU, offsetof (FreeFleetData_PathRequest, path),
   sizeof (FreeFleetData_Location), (17u << 16u) + 4u,
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_Location, sec),
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_Location, nanosec),
@@ -103,18 +130,45 @@ static const uint32_t FreeFleetData_Path_ops [] =
   DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_Location, yaw),
   DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_Location, level_name),
   DDS_OP_RTS,
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_PathRequest, task_id),
   DDS_OP_RTS
 };
 
-const dds_topic_descriptor_t FreeFleetData_Path_desc =
+const dds_topic_descriptor_t FreeFleetData_PathRequest_desc =
 {
-  sizeof (FreeFleetData_Path),
+  sizeof (FreeFleetData_PathRequest),
   sizeof (char *),
   DDS_TOPIC_NO_OPTIMIZE,
   0u,
-  "FreeFleetData::Path",
+  "FreeFleetData::PathRequest",
   NULL,
-  10,
-  FreeFleetData_Path_ops,
-  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"Path\"><Member name=\"path\"><Sequence><Type name=\"Location\"/></Sequence></Member></Struct></Module></MetaData>"
+  11,
+  FreeFleetData_PathRequest_ops,
+  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"PathRequest\"><Member name=\"path\"><Sequence><Type name=\"Location\"/></Sequence></Member><Member name=\"task_id\"><String/></Member></Struct></Module></MetaData>"
+};
+
+
+static const uint32_t FreeFleetData_DestinationRequest_ops [] =
+{
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_DestinationRequest, location.sec),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_DestinationRequest, location.nanosec),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_DestinationRequest, location.x),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_DestinationRequest, location.y),
+  DDS_OP_ADR | DDS_OP_TYPE_4BY, offsetof (FreeFleetData_DestinationRequest, location.yaw),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_DestinationRequest, location.level_name),
+  DDS_OP_ADR | DDS_OP_TYPE_STR, offsetof (FreeFleetData_DestinationRequest, task_id),
+  DDS_OP_RTS
+};
+
+const dds_topic_descriptor_t FreeFleetData_DestinationRequest_desc =
+{
+  sizeof (FreeFleetData_DestinationRequest),
+  sizeof (char *),
+  DDS_TOPIC_NO_OPTIMIZE,
+  0u,
+  "FreeFleetData::DestinationRequest",
+  NULL,
+  8,
+  FreeFleetData_DestinationRequest_ops,
+  "<MetaData version=\"1.0.0\"><Module name=\"FreeFleetData\"><Struct name=\"Location\"><Member name=\"sec\"><Long/></Member><Member name=\"nanosec\"><ULong/></Member><Member name=\"x\"><Float/></Member><Member name=\"y\"><Float/></Member><Member name=\"yaw\"><Float/></Member><Member name=\"level_name\"><String/></Member></Struct><Struct name=\"DestinationRequest\"><Member name=\"location\"><Type name=\"Location\"/></Member><Member name=\"task_id\"><String/></Member></Struct></Module></MetaData>"
 };

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.h
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.h
@@ -94,7 +94,7 @@ dds_sample_free ((d), &FreeFleetData_RobotState_desc, (o))
 
 typedef struct FreeFleetData_ModeRequest
 {
-  FreeFleetData_Location location;
+  FreeFleetData_RobotMode mode;
   char * task_id;
 } FreeFleetData_ModeRequest;
 

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.h
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.h
@@ -76,6 +76,7 @@ typedef struct FreeFleetData_RobotState
 {
   char * name;
   char * model;
+  char * task_id;
   FreeFleetData_RobotMode mode;
   float battery_percent;
   FreeFleetData_Location location;
@@ -90,33 +91,64 @@ extern const dds_topic_descriptor_t FreeFleetData_RobotState_desc;
 #define FreeFleetData_RobotState_free(d,o) \
 dds_sample_free ((d), &FreeFleetData_RobotState_desc, (o))
 
-typedef struct FreeFleetData_Path_path_seq
+
+typedef struct FreeFleetData_ModeRequest
+{
+  FreeFleetData_Location location;
+  char * task_id;
+} FreeFleetData_ModeRequest;
+
+extern const dds_topic_descriptor_t FreeFleetData_ModeRequest_desc;
+
+#define FreeFleetData_ModeRequest__alloc() \
+((FreeFleetData_ModeRequest*) dds_alloc (sizeof (FreeFleetData_ModeRequest)));
+
+#define FreeFleetData_ModeRequest_free(d,o) \
+dds_sample_free ((d), &FreeFleetData_ModeRequest_desc, (o))
+
+typedef struct FreeFleetData_PathRequest_path_seq
 {
   uint32_t _maximum;
   uint32_t _length;
   FreeFleetData_Location *_buffer;
   bool _release;
-} FreeFleetData_Path_path_seq;
+} FreeFleetData_PathRequest_path_seq;
 
-#define FreeFleetData_Path_path_seq__alloc() \
-((FreeFleetData_Path_path_seq*) dds_alloc (sizeof (FreeFleetData_Path_path_seq)));
+#define FreeFleetData_PathRequest_path_seq__alloc() \
+((FreeFleetData_PathRequest_path_seq*) dds_alloc (sizeof (FreeFleetData_PathRequest_path_seq)));
 
-#define FreeFleetData_Path_path_seq_allocbuf(l) \
+#define FreeFleetData_PathRequest_path_seq_allocbuf(l) \
 ((FreeFleetData_Location *) dds_alloc ((l) * sizeof (FreeFleetData_Location)))
 
 
-typedef struct FreeFleetData_Path
+typedef struct FreeFleetData_PathRequest
 {
-  FreeFleetData_Path_path_seq path;
-} FreeFleetData_Path;
+  FreeFleetData_PathRequest_path_seq path;
+  char * task_id;
+} FreeFleetData_PathRequest;
 
-extern const dds_topic_descriptor_t FreeFleetData_Path_desc;
+extern const dds_topic_descriptor_t FreeFleetData_PathRequest_desc;
 
-#define FreeFleetData_Path__alloc() \
-((FreeFleetData_Path*) dds_alloc (sizeof (FreeFleetData_Path)));
+#define FreeFleetData_PathRequest__alloc() \
+((FreeFleetData_PathRequest*) dds_alloc (sizeof (FreeFleetData_PathRequest)));
 
-#define FreeFleetData_Path_free(d,o) \
-dds_sample_free ((d), &FreeFleetData_Path_desc, (o))
+#define FreeFleetData_PathRequest_free(d,o) \
+dds_sample_free ((d), &FreeFleetData_PathRequest_desc, (o))
+
+
+typedef struct FreeFleetData_DestinationRequest
+{
+  FreeFleetData_Location location;
+  char * task_id;
+} FreeFleetData_DestinationRequest;
+
+extern const dds_topic_descriptor_t FreeFleetData_DestinationRequest_desc;
+
+#define FreeFleetData_DestinationRequest__alloc() \
+((FreeFleetData_DestinationRequest*) dds_alloc (sizeof (FreeFleetData_DestinationRequest)));
+
+#define FreeFleetData_DestinationRequest_free(d,o) \
+dds_sample_free ((d), &FreeFleetData_DestinationRequest_desc, (o))
 
 #ifdef __cplusplus
 }

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.idl
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.idl
@@ -26,13 +26,25 @@ module FreeFleetData
   {
     string name;
     string model;
+    string task_id;
     RobotMode mode;
     float battery_percent;
     Location location;
     sequence<Location> path;
   };
-  struct Path
+  struct ModeRequest
+  {
+    Location location;
+    string task_id;
+  };
+  struct PathRequest
   {
     sequence<Location> path;
+    string task_id;
+  };
+  struct DestinationRequest
+  {
+    Location location;
+    string task_id;
   };
 };

--- a/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.idl
+++ b/clients/ros1/free_fleet_client/src/free_fleet/FreeFleet.idl
@@ -34,7 +34,7 @@ module FreeFleetData
   };
   struct ModeRequest
   {
-    Location location;
+    RobotMode mode;
     string task_id;
   };
   struct PathRequest

--- a/clients/ros1/free_fleet_client/src/main.cpp
+++ b/clients/ros1/free_fleet_client/src/main.cpp
@@ -79,17 +79,18 @@ free_fleet::ClientConfig parse(int argc, char** argv)
       ("dds-state-topic", "name DDS topic for robot states",
           cxxopts::value<std::string>()->default_value(
               default_config.dds_state_topic))
-      ("dds-mode-topic", "name DDS topic for robot mode commands",
+      ("dds-mode-request-topic", "name DDS topic for robot mode requests",
           cxxopts::value<std::string>()->default_value(
-              default_config.dds_mode_command_topic))
-      ("dds-path-topic", "name DDS topic for robot path commands",
+              default_config.dds_mode_request_topic))
+      ("dds-path-request-topic", "name DDS topic for robot path requests",
           cxxopts::value<std::string>()->default_value(
-              default_config.dds_path_command_topic))
-      ("dds-location-topic", "name DDS topic for location commands",
+              default_config.dds_path_request_topic))
+      ("dds-destination-request-topic", 
+          "name DDS topic for destination requests",
           cxxopts::value<std::string>()->default_value(
-              default_config.dds_location_command_topic))
+              default_config.dds_destination_request_topic))
       ("update-frequency", 
-          "frequency at which the client updates all the states and commands",
+          "frequency at which the client updates all the states and requests",
           cxxopts::value<float>()->default_value(
               std::to_string(default_config.update_frequency)))
       ("publish-frequency", "frequency at which the client publishes states",
@@ -136,9 +137,9 @@ free_fleet::ClientConfig parse(int argc, char** argv)
       results["move-base"].as<std::string>(),
       results["dds-domain"].as<uint32_t>(),
       results["dds-state-topic"].as<std::string>(),
-      results["dds-mode-topic"].as<std::string>(),
-      results["dds-path-topic"].as<std::string>(),
-      results["dds-location-topic"].as<std::string>(),
+      results["dds-mode-request-topic"].as<std::string>(),
+      results["dds-path-request-topic"].as<std::string>(),
+      results["dds-destination-request-topic"].as<std::string>(),
       results["update-frequency"].as<float>(),
       results["publish-frequency"].as<float>()
     };
@@ -171,12 +172,12 @@ int main(int argc, char** argv)
       << config.dds_domain << std::endl;
   std::cout << "DDS - robot state topic:            " 
       << config.dds_state_topic << std::endl;
-  std::cout << "DDS - robot mode command topic:     " 
-      << config.dds_mode_command_topic << std::endl;
-  std::cout << "DDS - robot path command topic:     "
-      << config.dds_path_command_topic << std::endl;
-  std::cout << "DDS - robot location command topic: "
-      << config.dds_location_command_topic << std::endl;
+  std::cout << "DDS - robot mode request topic:     " 
+      << config.dds_mode_request_topic << std::endl;
+  std::cout << "DDS - robot path request topic:     "
+      << config.dds_path_request_topic << std::endl;
+  std::cout << "DDS - robot location request topic: "
+      << config.dds_destination_request_topic << std::endl;
   std::cout << "Client - update frequency: " << config.update_frequency
       << " Hz" << std::endl;
   std::cout << "Client - publish frequency: " << config.publish_frequency
@@ -190,7 +191,7 @@ int main(int argc, char** argv)
   auto client = free_fleet::Client::make(config);
 
   // Checks if the DDS client was created and is ready to roll
-  if (!client->is_ready())
+  if (!client)
   {
     ROS_ERROR("Client: unable to initialize.");
     return 1;

--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_destination_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_destination_request.cpp
@@ -28,8 +28,7 @@ int main (int argc, char ** argv)
   dds_entity_t writer;
   dds_return_t rc;
   dds_qos_t *qos;
-  FreeFleetData_Path* msg;
-  msg = FreeFleetData_Path__alloc();
+  FreeFleetData_DestinationRequest msg;
   uint32_t status = 0;
   (void)argc;
   (void)argv;
@@ -43,7 +42,7 @@ int main (int argc, char ** argv)
 
   /* Create a Topic. */
   topic = dds_create_topic (
-    participant, &FreeFleetData_Path_desc, "robot_path_command", 
+    participant, &FreeFleetData_DestinationRequest_desc, "destination_request", 
     NULL, NULL);
   if (topic < 0)
     DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
@@ -74,52 +73,20 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  msg->path._maximum = 4;
-  msg->path._length = 4;
-  msg->path._buffer = FreeFleetData_Path_path_seq_allocbuf(10);
-  msg->path._release = false;
-
-  msg->path._buffer[0].sec = 123;
-  msg->path._buffer[0].nanosec = 123;
-  msg->path._buffer[0].x = 0.735785007477;
-  msg->path._buffer[0].y = -1.78202533722;
-  msg->path._buffer[0].yaw = 0.0;
-  msg->path._buffer[0].level_name = dds_string_alloc(2);
-  msg->path._buffer[0].level_name[0] = 'B';
-  msg->path._buffer[0].level_name[1] = '1';
-  
-  msg->path._buffer[1].sec = 133;
-  msg->path._buffer[1].nanosec = 133;
-  msg->path._buffer[1].x = 1.09616982937;
-  msg->path._buffer[1].y = 1.89214968681;
-  msg->path._buffer[1].yaw = 0.0;
-  msg->path._buffer[1].level_name = dds_string_alloc(2);
-  msg->path._buffer[1].level_name[0] = 'B';
-  msg->path._buffer[1].level_name[1] = '1';
-
-  msg->path._buffer[2].sec = 143;
-  msg->path._buffer[2].nanosec = 143;
-  msg->path._buffer[2].x = -1.93706703186;
-  msg->path._buffer[2].y = 0.680773854256;
-  msg->path._buffer[2].yaw = 0.0;
-  msg->path._buffer[2].level_name = dds_string_alloc(2);
-  msg->path._buffer[2].level_name[0] = 'B';
-  msg->path._buffer[2].level_name[1] = '1';
-
-  msg->path._buffer[3].sec = 153;
-  msg->path._buffer[3].nanosec = 153;
-  msg->path._buffer[3].x = -1.98976910114;
-  msg->path._buffer[3].y = -0.43612909317;
-  msg->path._buffer[3].yaw = 0.0;
-  msg->path._buffer[3].level_name = dds_string_alloc(2);
-  msg->path._buffer[3].level_name[0] = 'B';
-  msg->path._buffer[3].level_name[1] = '1';
+  msg.location.sec = 123;
+  msg.location.nanosec = 123;
+  msg.location.x = 0.735785007477;
+  msg.location.y = -1.78202533722;
+  msg.location.yaw = 0.0;
+  msg.location.level_name = dds_string_alloc(2);
+  msg.location.level_name[0] = 'B';
+  msg.location.level_name[1] = '1';
 
   printf ("=== [Publisher]  Writing : ");
-  printf ("Message: path length %u\n", msg->path._length);
+  printf ("Message: level_name %s\n", msg.location.level_name);
   fflush (stdout);
 
-  rc = dds_write (writer, msg);
+  rc = dds_write (writer, &msg);
   if (rc != DDS_RETCODE_OK)
     DDS_FATAL("dds_write: %s\n", dds_strretcode(-rc));
 
@@ -128,6 +95,6 @@ int main (int argc, char ** argv)
   if (rc != DDS_RETCODE_OK)
     DDS_FATAL("dds_delete: %s\n", dds_strretcode(-rc));
 
-  FreeFleetData_Path_free(msg, DDS_FREE_ALL);
+  dds_string_free(msg.location.level_name);
   return EXIT_SUCCESS;
 }

--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_sim_path_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_sim_path_request.cpp
@@ -17,35 +17,19 @@
 
 #include "dds/dds.h"
 #include "../free_fleet/FreeFleet.h"
-#include <iostream>
 #include <stdio.h>
 #include <stdlib.h>
 #include <limits>
 
 int main (int argc, char ** argv)
 {
-  if (argc < 2)
-  {
-    std::cout << "Please select the robot mode command that you wish to send: "
-      << "pause, resume or emergency" << std::endl;
-    return 1;
-  }
-  std::string mode_command(argv[1]);
-  if (mode_command != "pause" && 
-      mode_command != "resume" &&
-      mode_command != "emergency")
-  {
-    std::cout << "Please select the robot mode command that you wish to send: "
-      << "pause, resume or emergency" << std::endl;
-    return 1;
-  }
-
   dds_entity_t participant;
   dds_entity_t topic;
   dds_entity_t writer;
   dds_return_t rc;
   dds_qos_t *qos;
-  FreeFleetData_RobotMode msg;
+  FreeFleetData_PathRequest* msg;
+  msg = FreeFleetData_PathRequest__alloc();
   uint32_t status = 0;
   (void)argc;
   (void)argv;
@@ -59,7 +43,7 @@ int main (int argc, char ** argv)
 
   /* Create a Topic. */
   topic = dds_create_topic (
-    participant, &FreeFleetData_RobotMode_desc, "robot_mode_command", 
+    participant, &FreeFleetData_PathRequest_desc, "path_request", 
     NULL, NULL);
   if (topic < 0)
     DDS_FATAL("dds_create_topic: %s\n", dds_strretcode(-topic));
@@ -90,18 +74,52 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  if (mode_command == "pause")
-    msg.mode = FreeFleetData_RobotMode_Constants_MODE_PAUSED;
-  else if (mode_command == "resume")
-    msg.mode = FreeFleetData_RobotMode_Constants_MODE_MOVING;
-  else if (mode_command == "emergency")
-    msg.mode = FreeFleetData_RobotMode_Constants_MODE_EMERGENCY;
+  msg->path._maximum = 4;
+  msg->path._length = 4;
+  msg->path._buffer = FreeFleetData_PathRequest_path_seq_allocbuf(10);
+  msg->path._release = false;
+
+  msg->path._buffer[0].sec = 123;
+  msg->path._buffer[0].nanosec = 123;
+  msg->path._buffer[0].x = 0.735785007477;
+  msg->path._buffer[0].y = -1.78202533722;
+  msg->path._buffer[0].yaw = 0.0;
+  msg->path._buffer[0].level_name = dds_string_alloc(2);
+  msg->path._buffer[0].level_name[0] = 'B';
+  msg->path._buffer[0].level_name[1] = '1';
   
+  msg->path._buffer[1].sec = 133;
+  msg->path._buffer[1].nanosec = 133;
+  msg->path._buffer[1].x = 1.09616982937;
+  msg->path._buffer[1].y = 1.89214968681;
+  msg->path._buffer[1].yaw = 0.0;
+  msg->path._buffer[1].level_name = dds_string_alloc(2);
+  msg->path._buffer[1].level_name[0] = 'B';
+  msg->path._buffer[1].level_name[1] = '1';
+
+  msg->path._buffer[2].sec = 143;
+  msg->path._buffer[2].nanosec = 143;
+  msg->path._buffer[2].x = -1.93706703186;
+  msg->path._buffer[2].y = 0.680773854256;
+  msg->path._buffer[2].yaw = 0.0;
+  msg->path._buffer[2].level_name = dds_string_alloc(2);
+  msg->path._buffer[2].level_name[0] = 'B';
+  msg->path._buffer[2].level_name[1] = '1';
+
+  msg->path._buffer[3].sec = 153;
+  msg->path._buffer[3].nanosec = 153;
+  msg->path._buffer[3].x = -1.98976910114;
+  msg->path._buffer[3].y = -0.43612909317;
+  msg->path._buffer[3].yaw = 0.0;
+  msg->path._buffer[3].level_name = dds_string_alloc(2);
+  msg->path._buffer[3].level_name[0] = 'B';
+  msg->path._buffer[3].level_name[1] = '1';
+
   printf ("=== [Publisher]  Writing : ");
-  printf ("Message: mode_command %s\n", mode_command.c_str());
+  printf ("Message: path length %u\n", msg->path._length);
   fflush (stdout);
 
-  rc = dds_write (writer, &msg);
+  rc = dds_write (writer, msg);
   if (rc != DDS_RETCODE_OK)
     DDS_FATAL("dds_write: %s\n", dds_strretcode(-rc));
 
@@ -110,5 +128,6 @@ int main (int argc, char ** argv)
   if (rc != DDS_RETCODE_OK)
     DDS_FATAL("dds_delete: %s\n", dds_strretcode(-rc));
 
+  FreeFleetData_PathRequest_free(msg, DDS_FREE_ALL);
   return EXIT_SUCCESS;
 }

--- a/docs/clients_test.md
+++ b/docs/clients_test.md
@@ -22,21 +22,21 @@ The client will then start subscribing to all the necessary topics, and start pu
 rosrun free_fleet_client test_dds_sub_state
 ```
 
-The client will also be listening for commands over DDS, which will trigger action server calls for `MoveBase`. To demonstrate this behaviour
+The client will also be listening for requests over DDS, which will trigger action server calls for `MoveBase`. To demonstrate this behaviour
 
 ```bash
-# sends out a single location command to the robot over DDS
-rosrun free_fleet_client test_dds_pub_location_command
+# sends out a single destination request to the robot over DDS
+rosrun free_fleet_client test_dds_pub_destination_request
 
-# sends out a path command, basically a sequence of location commands to the robot over DDS
-rosrun free_fleet_client test_dds_pub_path_command
+# sends out a path request, basically a sequence of destination requests to the robot over DDS
+rosrun free_fleet_client test_dds_pub_path_request
 
-# sends out a path command with locations corresponding to real map locations
-rosrun free_fleet_client test_dds_pub_sim_location_command
+# sends out a path request with locations corresponding to real map locations
+rosrun free_fleet_client test_dds_pub_sim_path_request
 
-# sends out a mode command, to pause and resume what it is doing
-rosrun free_fleet_client test_dds_pub_mode_command pause
-rosrun free_fleet_client test_dds_pub_mode_command ressume
+# sends out a mode request, to pause and resume what it is doing
+rosrun free_fleet_client test_dds_pub_mode_request pause
+rosrun free_fleet_client test_dds_pub_mode_request ressume
 ```
 
 # Client simulation test
@@ -59,11 +59,11 @@ Use the flag `-h` for more information about the default values of all optional 
 Similar to the section above, the built test executables can now be run to control and monitor the robot. We recommend using the `map.yaml` map, which corresponds to `turtlebot3_world` in the ROBOTIS examples.
 
 ```bash
-# location command
-rosrun free_fleet_client test_dds_pub_location_command
+# destination request
+rosrun free_fleet_client test_dds_pub_destination_request
 
-# path command
-rosrun free_fleet_client test_dds_sim_path_command
+# path request
+rosrun free_fleet_client test_dds_pub_sim_path_request
 ```
 
 While the simulation is running, the robot's state can be observed by calling the DDS subscribing executable,


### PR DESCRIPTION
* changed message definitions to mimic newer request messages in `rmf_fleet_msgs`, added `task_id` field as well

* changed to use `request` instead of `command` to follow convention

* change to use all the new request DDS messages

* changed up documentation a bit