### PR TITLE
added arg parsing for task_id on testing scripts

### DIFF
--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_destination_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_destination_request.cpp
@@ -26,16 +26,18 @@
 
 int main (int argc, char ** argv)
 {
-  if (argc < 4)
+  if (argc < 5)
   {
-    std::cout << "Please select the destination coordinates for the request after the executable, ";
-    std::cout << std::endl << "For example, <exec> 0.0 0.0 0.0" << std::endl;
+    std::cout << "Please select the destination coordinates and task ID for the request after the "
+        << "executable, " << std::endl;
+    std::cout << "For example, <exec> 0.0 0.0 0.0" << std::endl;
     return 1;
   }
 
   double x = strtod(argv[1], NULL);
   double y = strtod(argv[2], NULL);
   double yaw = strtod(argv[3], NULL);
+  std::string task_id(argv[4]); 
 
   dds_entity_t participant;
   dds_entity_t topic;
@@ -88,7 +90,6 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  std::string task_id = "SWEET_CHIN_MUSIC";
   std::string level_name = "B1";
   
   msg->task_id = free_fleet::common::dds_string_alloc_and_copy(task_id);

--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_mode_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_mode_request.cpp
@@ -27,10 +27,10 @@
 
 int main (int argc, char ** argv)
 {
-  if (argc < 2)
+  if (argc < 3)
   {
-    std::cout << "Please select the robot mode command that you wish to send: "
-      << "pause, resume or emergency" << std::endl;
+    std::cout << "Please select the robot mode command and task ID that you wish to send: "
+      << "pause, resume or emergency, then <task_id>" << std::endl;
     return 1;
   }
   std::string mode_command(argv[1]);
@@ -42,6 +42,8 @@ int main (int argc, char ** argv)
       << "pause, resume or emergency" << std::endl;
     return 1;
   }
+
+  std::string task_id(argv[2]);
 
   dds_entity_t participant;
   dds_entity_t topic;
@@ -94,7 +96,6 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  std::string task_id = "PEOPLES_ELBOW";
   msg->task_id = free_fleet::common::dds_string_alloc_and_copy(task_id);
 
   if (mode_command == "pause")

--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_path_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_path_request.cpp
@@ -26,6 +26,13 @@
 
 int main (int argc, char ** argv)
 {
+  if (argc < 2)
+  {
+    std::cout << "Please provide a task ID." << std::endl;
+    return 1;
+  }
+  std::string task_id(argv[1]);
+
   dds_entity_t participant;
   dds_entity_t topic;
   dds_entity_t writer;
@@ -77,7 +84,6 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  std::string task_id = "STONE_COLD_STUNNER";
   std::string level_name = "B1";
 
   msg->task_id = free_fleet::common::dds_string_alloc_and_copy(task_id);

--- a/clients/ros1/free_fleet_client/src/tests/test_dds_pub_sim_path_request.cpp
+++ b/clients/ros1/free_fleet_client/src/tests/test_dds_pub_sim_path_request.cpp
@@ -26,6 +26,13 @@
 
 int main (int argc, char ** argv)
 {
+  if (argc < 2)
+  {
+    std::cout << "Please provide a task ID." << std::endl;
+    return 1;
+  }
+  std::string task_id(argv[1]);
+
   dds_entity_t participant;
   dds_entity_t topic;
   dds_entity_t writer;
@@ -77,7 +84,6 @@ int main (int argc, char ** argv)
   }
 
   /* Create a message to write. */
-  std::string task_id = "SPACE_FORCE";
   std::string level_name = "B1";
 
   msg->task_id = free_fleet::common::dds_string_alloc_and_copy(task_id);


### PR DESCRIPTION
* added arg parsing for `task_id` to testing executables, as client ignores request if already executing the same `task_id`