### PR TITLE
Fix/mode adapter error

### DIFF
--- a/free_fleet/include/free_fleet/messages/RobotMode.hpp
+++ b/free_fleet/include/free_fleet/messages/RobotMode.hpp
@@ -34,6 +34,7 @@ struct RobotMode
   static const uint32_t MODE_EMERGENCY = 5;
   static const uint32_t MODE_GOING_HOME = 6;
   static const uint32_t MODE_DOCKING = 7;
+  static const uint32_t MODE_REQUEST_ERROR = 8;
 };
 
 } // namespace messages

--- a/free_fleet/src/messages/FleetMessages.h
+++ b/free_fleet/src/messages/FleetMessages.h
@@ -25,6 +25,7 @@ extern "C" {
 #define FreeFleetData_RobotMode_Constants_MODE_EMERGENCY 5
 #define FreeFleetData_RobotMode_Constants_MODE_GOING_HOME 6
 #define FreeFleetData_RobotMode_Constants_MODE_DOCKING 7
+#define FreeFleetData_RobotMode_Constants_MODE_REQUEST_ERROR 8
 
 
 typedef struct FreeFleetData_RobotMode

--- a/free_fleet/src/messages/FleetMessages.idl
+++ b/free_fleet/src/messages/FleetMessages.idl
@@ -10,6 +10,7 @@ module FreeFleetData
     const unsigned long MODE_EMERGENCY = 5;
     const unsigned long MODE_GOING_HOME = 6;
     const unsigned long MODE_DOCKING = 7;
+    const unsigned long MODE_REQUEST_ERROR = 8;
   };
   struct RobotMode
   {

--- a/free_fleet/src/messages/message_utils.cpp
+++ b/free_fleet/src/messages/message_utils.cpp
@@ -26,56 +26,16 @@ namespace messages {
 
 void convert(const RobotMode& _input, FreeFleetData_RobotMode& _output)
 {
-  switch(_input.mode)
-  {
-    case RobotMode::MODE_CHARGING:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_CHARGING;
-      break;
-    case RobotMode::MODE_MOVING:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_MOVING;
-      break;
-    case RobotMode::MODE_PAUSED:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_PAUSED;
-      break;
-    case RobotMode::MODE_WAITING:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_WAITING;
-      break;
-    case RobotMode::MODE_EMERGENCY:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_EMERGENCY;
-      break;
-    case RobotMode::MODE_GOING_HOME:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_GOING_HOME;
-      break;
-    default:
-      _output.mode = FreeFleetData_RobotMode_Constants_MODE_IDLE;
-  }
+  // Consequently, free fleet robot modes need to be ordered similarly as 
+  // RMF robot modes.
+  _output.mode = _input.mode;
 }
 
 void convert(const FreeFleetData_RobotMode& _input, RobotMode& _output)
 {
-  switch(_input.mode)
-  {
-    case FreeFleetData_RobotMode_Constants_MODE_CHARGING:
-      _output.mode = RobotMode::MODE_CHARGING;
-      break;
-    case FreeFleetData_RobotMode_Constants_MODE_MOVING:
-      _output.mode = RobotMode::MODE_MOVING;
-      break;
-    case FreeFleetData_RobotMode_Constants_MODE_PAUSED:
-      _output.mode = RobotMode::MODE_PAUSED;
-      break;
-    case FreeFleetData_RobotMode_Constants_MODE_WAITING:
-      _output.mode = RobotMode::MODE_WAITING;
-      break;
-    case FreeFleetData_RobotMode_Constants_MODE_EMERGENCY:
-      _output.mode = RobotMode::MODE_EMERGENCY;
-      break;
-    case FreeFleetData_RobotMode_Constants_MODE_GOING_HOME:
-      _output.mode = RobotMode::MODE_GOING_HOME;
-      break;
-    default:
-      _output.mode = RobotMode::MODE_IDLE;
-  }
+  // Consequently, free fleet robot modes need to be ordered similarly as 
+  // RMF robot modes.
+  _output.mode = _input.mode;
 }
 
 void convert(const Location& _input, FreeFleetData_Location& _output)

--- a/free_fleet_client_ros1/src/ClientNode.cpp
+++ b/free_fleet_client_ros1/src/ClientNode.cpp
@@ -232,8 +232,8 @@ void ClientNode::publish_robot_state()
     }
   }
 
-  if (fields.client->send_robot_state(new_robot_state))
-    ROS_INFO("sent robot state: msg sec %u", new_robot_state.location.sec);
+  if (!fields.client->send_robot_state(new_robot_state))
+    ROS_WARN("failed to send robot state: msg sec %u", new_robot_state.location.sec);
 }
 
 bool ClientNode::is_valid_request(

--- a/free_fleet_client_ros1/src/ClientNode.hpp
+++ b/free_fleet_client_ros1/src/ClientNode.hpp
@@ -128,8 +128,9 @@ private:
 
   // TODO: conditions to trigger emergency, however this is most likely for
   // indicating emergency within the fleet and not in RMF
+  // TODO: figure out a better way to handle multiple triggered modes
+  std::atomic<bool> request_error;
   std::atomic<bool> emergency;
-
   std::atomic<bool> paused;
 
   messages::RobotMode get_robot_mode();

--- a/free_fleet_server_ros2/src/utilities.hpp
+++ b/free_fleet_server_ros2/src/utilities.hpp
@@ -53,6 +53,10 @@ void to_ff_message(
 // ----------------------------------------------------------------------------
 
 void to_ros_message(
+    const messages::Location& in_msg,
+    rmf_fleet_msgs::msg::Location& out_msg);
+
+void to_ros_message(
     const messages::RobotState& in_msg,
     rmf_fleet_msgs::msg::RobotState& out_msg);
 


### PR DESCRIPTION
This PR addresses the added robot mode `MODE_ADAPTER_ERROR` that is defined [here](https://github.com/osrf/rmf_core/blob/develop/rmf_fleet_msgs/msg/RobotMode.msg). The fixes have tested it in simulation with instructions to recreate below. These fixes are quick and dirty, and will be reworked in a better manner during the full re-write of Free Fleet that is underway.

* Added handling of `MODE_ADAPTER_ERROR`, in the domain of Free Fleet, it is named `MODE_REQUEST_ERROR` as there is no information about adapters yet
* When first waypoint of a path request is too far away (distance more than `max_dist_to_first_waypoint` in configuration), `MODE_REQUEST_ERROR` will be triggered, and robot will be commanded to stay put and wait for next valid request
* cleaned up client's logging, only when warnings arises, eg. first waypoint of path command too far

## Test
Prepare the ROS1 and ROS2 workspaces according to instructions from the README, be sure the checkout this branch before building each workspace, and the `develop` branch of `rmf_core` for the ROS2 workspace.  

Launch the multi-turtlebot3 simulation from the ROS1 workspace,
```
source ~/client_ws/devel/setup.bash
export TURTLEBOT3_MODEL=burger; roslaunch ff_examples_ros1 multi_turtlebot3_ff.launch
```

Launch the server from the ROS2 workspace, it should register all 3 robots in simulation as clients,
```
source ~/server_ws/install/setup.bash
ros2 launch ff_examples_ros2 turtlebot3_world_ff.launch.xml
```

Send a path request that has its first waypoint too far from the bottom-most turtlebot3, `tb3_0`,
```
source ~/server_ws/install/setup.bash
ros2 run ff_examples_ros2 send_path_request.py \
    -f turtlebot3 -r tb3_0 -i random_id \
    -p '[{"x": 5.9149, "y": -4.046, "yaw": 0.0, "level_name": ""}, {"x": 6.611, "y": -2.685, "yaw": 0.0, "level_name": ""}]'
```

On the ROS1 terminal, you should see a warning that the distance is too far, while the robot in simulation doesn't move.

Check the robot's mode using `ros2 topic echo /fleet_states`, the robot `tb3_0`'s mode should now be `8`, which corresponds to `MODE_ADAPTER_ERROR`.

Now, send a valid path request that is within reach to the same robot,
```
source ~/server_ws/install/setup.bash
ros2 run ff_examples_ros2 send_path_request.py \
    -f turtlebot3 -r tb3_0 -i another_random_id \
    -p '[{"x": -6.10281848907, "y": 2.64789390564, "yaw": 0.0, "level_name": ""}, {"x": -4.11846208572, "y": 1.303637743, "yaw": 0.0, "level_name": ""}]'
```

The request should be received by the client, the robot should start navigating to the first waypoint in the request, while its mode should not be `8` anymore